### PR TITLE
Implement user role binding phase

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -646,6 +646,7 @@
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "k8s.io/api/core/v1",
+    "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -16,8 +16,6 @@ spec:
       properties:
         spec:
           properties:
-            namespace:
-              type: string
             username:
               type: string
             services:

--- a/deploy/examples/walkthrough.yaml
+++ b/deploy/examples/walkthrough.yaml
@@ -3,8 +3,6 @@ kind: "Walkthrough"
 metadata:
   name: "example"
 spec:
-  #The target namespace where the services will be provisioned
-  namespace: example
   #The username of the user who initiated the walkthough from the launcher app
   username: developer
   #A list of services required by the walkthrough

--- a/pkg/apis/integreatly/v1alpha1/types.go
+++ b/pkg/apis/integreatly/v1alpha1/types.go
@@ -27,15 +27,15 @@ type Walkthrough struct {
 }
 
 type WalkthroughSpec struct {
-	Namespace string   `json:"namespace"`
-	UserName  string   `json:"username"`
-	Services  []string `json:"services,omitempty"`
+	UserName string   `json:"username"`
+	Services []string `json:"services,omitempty"`
 }
 
 type WalkthroughStatus struct {
 	// marked as true when all work is done on it
-	Ready bool        `json:"ready"`
-	Phase StatusPhase `json:"phase"`
+	Ready     bool        `json:"ready"`
+	Phase     StatusPhase `json:"phase"`
+	Namespace string      `json:"namespace"`
 }
 
 type StatusPhase string

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -47,16 +48,16 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 				return errors.Wrap(err, "phase provision namespace failed")
 			}
 			return sdk.Update(wtState)
-		case v1alpha1.PhaseProvisionServices:
-			wtState, err := h.provisionServices(o)
-			if err != nil {
-				return errors.Wrap(err, "phase provision services failed")
-			}
-			return sdk.Update(wtState)
 		case v1alpha1.PhaseUserRoleBindings:
 			wtState, err := h.userRoleBindings(o)
 			if err != nil {
 				return errors.Wrap(err, "phase user role binding failed")
+			}
+			return sdk.Update(wtState)
+		case v1alpha1.PhaseProvisionServices:
+			wtState, err := h.provisionServices(o)
+			if err != nil {
+				return errors.Wrap(err, "phase provision services failed")
 			}
 			return sdk.Update(wtState)
 		}
@@ -80,12 +81,26 @@ func (h *Handler) provisionNamespace(wt *v1alpha1.Walkthrough) (*v1alpha1.Walkth
 		},
 	}
 
-	namespace, err := h.k8sClient.CoreV1().Namespaces().Create(nsSpec)
+	_, err := h.k8sClient.CoreV1().Namespaces().Create(nsSpec)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create wlakthrouh namespace")
+		return nil, errors.Wrap(err, "failed to create walkthrough namespace")
 	}
 
-	logrus.Debugf("namespace %+v", namespace)
+	wtCopy.Status.Phase = v1alpha1.PhaseUserRoleBindings
+	return wtCopy, nil
+}
+
+func (h *Handler) userRoleBindings(wt *v1alpha1.Walkthrough) (*v1alpha1.Walkthrough, error) {
+	wtCopy := wt.DeepCopy()
+
+	userRoles := []string{"view", "edit"}
+
+	for _, role := range userRoles {
+		err := sdk.Create(newRoleBinding(wt.Spec.UserName, wt.Spec.Namespace, role))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create user %s role binding", role)
+		}
+	}
 
 	wtCopy.Status.Phase = v1alpha1.PhaseProvisionServices
 	return wtCopy, nil
@@ -97,8 +112,27 @@ func (h *Handler) provisionServices(wt *v1alpha1.Walkthrough) (*v1alpha1.Walkthr
 	return wtCopy, nil
 }
 
-func (h *Handler) userRoleBindings(wt *v1alpha1.Walkthrough) (*v1alpha1.Walkthrough, error) {
-	wtCopy := wt.DeepCopy()
-	//ToDo Implement me
-	return wtCopy, nil
+func newRoleBinding(username, namsepace, roleName string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: roleName + "-",
+			Namespace:    namsepace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     roleName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     username,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	}
 }


### PR DESCRIPTION
* Adds a role binding allowing the user defined in the walkthrough cr to view the namespace created.
* Generate namespace name based on the username, removed "namespace" from the crd.
* Add labels to resources created by this operator.

**Verification**

Run the operator locally:

```make run```

Create a user that has no elevated permissions:

```oc create user testuser --full-name=testuser```

Create a new walkthrough crd:

```.yml
apiVersion: "integreatly.aerogear.org/v1alpha1"
kind: "Walkthrough"
metadata:
  name: "testuserrole"
spec:
  username: testuser
  services:
   - fuse
```
```
kubectl create -f testuserrole.yaml -n integreatly
```

Verify that when you login as the  "testuser" user you can view the "testuser-walkthroughs" namespace.
